### PR TITLE
Add authentication to Book API and clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj/
 BookApiConsumer.TypeScript/code-model-v1
 .vs/
 BookApiConsumer.TypeScript/dist/
+IdentityServer/tempkey.jwk

--- a/BookApi/Controllers/AuthorsController.cs
+++ b/BookApi/Controllers/AuthorsController.cs
@@ -1,5 +1,6 @@
 ﻿using BookApi.Models;
 using BookApi.OpenApi;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -9,6 +10,7 @@ using System.Linq;
 namespace BookApi.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     [Consumes(contentType: ContentTypes.APPLICATION_JSON)]
     [Produces(contentType: ContentTypes.APPLICATION_JSON)]

--- a/BookApi/Controllers/BooksController.cs
+++ b/BookApi/Controllers/BooksController.cs
@@ -1,5 +1,6 @@
 ﻿using BookApi.Models;
 using BookApi.OpenApi;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -7,6 +8,7 @@ using System.Collections.Generic;
 namespace BookApi.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("[controller]")]
     [Consumes(contentType: ContentTypes.APPLICATION_JSON)]
     [Produces(contentType: ContentTypes.APPLICATION_JSON)]

--- a/BookApi/Startup.cs
+++ b/BookApi/Startup.cs
@@ -34,6 +34,16 @@ namespace BookApi
                 // remove this line and check
                 // https://stackoverflow.com/questions/60222469/swagger-c-sharp-enum-generation-underlying-int-values-do-not-match-the-
                 .AddJsonOptions(o => { o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); });
+
+            services.AddAuthentication("Bearer")
+                .AddJwtBearer("Bearer", options =>
+                {
+                    options.Authority = "http://localhost:5000";
+                    options.RequireHttpsMetadata = false;
+
+                    options.Audience = "book-api";
+                });
+
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "BookApi", Version = "v1" });
@@ -78,6 +88,7 @@ namespace BookApi
 
             app.UseRouting();
 
+            app.UseAuthentication();
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>

--- a/BookApiClient/Authors.cs
+++ b/BookApiClient/Authors.cs
@@ -98,6 +98,12 @@ namespace Clients
 
             // Serialize Request
             string _requestContent = null;
+            // Set Credentials
+            if (Client.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
             // Send Request
             if (_shouldTrace)
             {
@@ -224,6 +230,12 @@ namespace Clients
                 _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
             }
+            // Set Credentials
+            if (Client.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
             // Send Request
             if (_shouldTrace)
             {
@@ -345,6 +357,12 @@ namespace Clients
 
             // Serialize Request
             string _requestContent = null;
+            // Set Credentials
+            if (Client.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
             // Send Request
             if (_shouldTrace)
             {

--- a/BookApiClient/BookApiClient.cs
+++ b/BookApiClient/BookApiClient.cs
@@ -33,6 +33,11 @@ namespace Clients
         public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
+        /// Subscription credentials which uniquely identify client subscription.
+        /// </summary>
+        public ServiceClientCredentials Credentials { get; private set; }
+
+        /// <summary>
         /// Gets the IAuthors.
         /// </summary>
         public virtual IAuthors Authors { get; private set; }
@@ -50,7 +55,7 @@ namespace Clients
         /// </param>
         /// <param name='disposeHttpClient'>
         /// True: will dispose the provided httpClient on calling BookApiClient.Dispose(). False: will not dispose provided httpClient</param>
-        public BookApiClient(HttpClient httpClient, bool disposeHttpClient) : base(httpClient, disposeHttpClient)
+        protected BookApiClient(HttpClient httpClient, bool disposeHttpClient) : base(httpClient, disposeHttpClient)
         {
             Initialize();
         }
@@ -61,7 +66,7 @@ namespace Clients
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
-        public BookApiClient(params DelegatingHandler[] handlers) : base(handlers)
+        protected BookApiClient(params DelegatingHandler[] handlers) : base(handlers)
         {
             Initialize();
         }
@@ -75,7 +80,7 @@ namespace Clients
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
-        public BookApiClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
+        protected BookApiClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
             Initialize();
         }
@@ -92,7 +97,7 @@ namespace Clients
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BookApiClient(System.Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
+        protected BookApiClient(System.Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -116,13 +121,162 @@ namespace Clients
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BookApiClient(System.Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        protected BookApiClient(System.Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
                 throw new System.ArgumentNullException("baseUri");
             }
             BaseUri = baseUri;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BookApiClient class.
+        /// </summary>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public BookApiClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BookApiClient class.
+        /// </summary>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='httpClient'>
+        /// HttpClient to be used
+        /// </param>
+        /// <param name='disposeHttpClient'>
+        /// True: will dispose the provided httpClient on calling BookApiClient.Dispose(). False: will not dispose provided httpClient</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public BookApiClient(ServiceClientCredentials credentials, HttpClient httpClient, bool disposeHttpClient) : this(httpClient, disposeHttpClient)
+        {
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BookApiClient class.
+        /// </summary>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The http client handler used to handle http transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public BookApiClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BookApiClient class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public BookApiClient(System.Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new System.ArgumentNullException("baseUri");
+            }
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            BaseUri = baseUri;
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the BookApiClient class.
+        /// </summary>
+        /// <param name='baseUri'>
+        /// Optional. The base URI of the service.
+        /// </param>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='rootHandler'>
+        /// Optional. The http client handler used to handle http transport.
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public BookApiClient(System.Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        {
+            if (baseUri == null)
+            {
+                throw new System.ArgumentNullException("baseUri");
+            }
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            BaseUri = baseUri;
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>

--- a/BookApiClient/Books.cs
+++ b/BookApiClient/Books.cs
@@ -101,6 +101,12 @@ namespace Clients
 
             // Serialize Request
             string _requestContent = null;
+            // Set Credentials
+            if (Client.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
             // Send Request
             if (_shouldTrace)
             {

--- a/BookApiClient/IBookApiClient.cs
+++ b/BookApiClient/IBookApiClient.cs
@@ -6,6 +6,7 @@
 
 namespace Clients
 {
+    using Microsoft.Rest;
     using Models;
     using Newtonsoft.Json;
 
@@ -27,6 +28,12 @@ namespace Clients
         /// Gets or sets json deserialization settings.
         /// </summary>
         JsonSerializerSettings DeserializationSettings { get; }
+
+        /// <summary>
+        /// Subscription credentials which uniquely identify client
+        /// subscription.
+        /// </summary>
+        ServiceClientCredentials Credentials { get; }
 
 
         /// <summary>

--- a/BookApiClient/readme.md
+++ b/BookApiClient/readme.md
@@ -19,4 +19,5 @@ csharp:
   namespace: Clients 
   override-client-name: BookApiClient
   client-side-validation: false # disable client side validation of constraints
+  add-credentials: true
 ```

--- a/BookApiConsumer.TypeScript/package-lock.json
+++ b/BookApiConsumer.TypeScript/package-lock.json
@@ -27,6 +27,11 @@
       "integrity": "sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==",
       "dev": true
     },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog=="
+    },
     "@types/node": {
       "version": "14.14.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
@@ -51,6 +56,15 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/superagent": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.10.tgz",
+      "integrity": "sha512-xAgkb2CMWUMCyVc/3+7iQfOEBE75NvuZeezvmixbUw3nmENf2tCnQkW5yQLTYqvXUQ+R6EXxdqKKbal2zM5V/g==",
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
       }
     },
     "@types/tunnel": {
@@ -88,6 +102,24 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -97,6 +129,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "form-data": {
       "version": "2.5.1",
@@ -108,10 +145,38 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -125,6 +190,11 @@
       "requires": {
         "mime-db": "1.44.0"
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -141,10 +211,76 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "tough-cookie": {
       "version": "3.0.1",
@@ -171,6 +307,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -189,6 +330,11 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/BookApiConsumer.TypeScript/package.json
+++ b/BookApiConsumer.TypeScript/package.json
@@ -12,10 +12,12 @@
   "license": "ISC",
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",
+    "@types/superagent": "^4.1.10",
     "autorest": "^3.0.6322"
   },
   "dependencies": {
     "@azure/ms-rest-js": "^2.1.0",
+    "superagent": "^6.1.0",
     "typescript": "^4.1.3"
   }
 }

--- a/BookApiConsumer.TypeScript/readme.md
+++ b/BookApiConsumer.TypeScript/readme.md
@@ -18,4 +18,5 @@ typescript:
   override-client-name: BookApiClient
   client-side-validation: false # disable client side validation of constraints
   enum-types: true
+  add-credentials: true
 ```

--- a/BookApiConsumer.TypeScript/src/book-api-client/bookApiClient.ts
+++ b/BookApiConsumer.TypeScript/src/book-api-client/bookApiClient.ts
@@ -4,6 +4,7 @@
  * regenerated.
  */
 
+import * as msRest from "@azure/ms-rest-js";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -16,10 +17,11 @@ class BookApiClient extends BookApiClientContext {
 
   /**
    * Initializes a new instance of the BookApiClient class.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(options?: Models.BookApiClientOptions) {
-    super(options);
+  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.BookApiClientOptions) {
+    super(credentials, options);
     this.authors = new operations.Authors(this);
     this.books = new operations.Books(this);
   }

--- a/BookApiConsumer.TypeScript/src/book-api-client/bookApiClientContext.ts
+++ b/BookApiConsumer.TypeScript/src/book-api-client/bookApiClientContext.ts
@@ -11,12 +11,18 @@ const packageName = "";
 const packageVersion = "1.0.0";
 
 export class BookApiClientContext extends msRest.ServiceClient {
+  credentials: msRest.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the BookApiClientContext class.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(options?: Models.BookApiClientOptions) {
+  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.BookApiClientOptions) {
+    if (credentials == undefined) {
+      throw new Error("'credentials' cannot be null.");
+    }
+
     if (!options) {
       options = {};
     }
@@ -26,9 +32,10 @@ export class BookApiClientContext extends msRest.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(undefined, options);
+    super(credentials, options);
 
     this.baseUri = options.baseUri || this.baseUri || "http://localhost";
     this.requestContentType = "application/json; charset=utf-8";
+    this.credentials = credentials;
   }
 }

--- a/BookApiConsumer.TypeScript/src/call-api.ts
+++ b/BookApiConsumer.TypeScript/src/call-api.ts
@@ -1,9 +1,23 @@
 import { BookApiClient } from './book-api-client/bookApiClient'
+import * as superAgent from 'superagent';
+import { TokenCredentials } from '@azure/ms-rest-js';
+
 
 async function QueryAuthors() {
-    const client = new BookApiClient({ baseUri: 'http://localhost:5000' });
-    const authors = await client.authors.getAll();
-    authors.forEach(author => console.log(`Author: ${author.name}`))
+    let accessToken;
+
+    try {
+        const response = await superAgent.post('http://localhost:5000/connect/token')
+            .send('client_id=book-api-consumer&client_secret=secret&grant_type=client_credentials');
+
+        const client = new BookApiClient(new TokenCredentials(response.body.access_token),
+            { baseUri: 'http://localhost:5001' });
+        const authors = await client.authors.getAll();
+        authors.forEach(author => console.log(`Author: ${author.name}`))
+
+    } catch (error) {
+        console.log(error);
+    }
 }
 
 QueryAuthors();

--- a/BookApiConsumer/BookApiConsumer.csproj
+++ b/BookApiConsumer/BookApiConsumer.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\BookApiClient\BookApiClient.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="IdentityModel" Version="4.5.0" />
+  </ItemGroup>
+
 </Project>

--- a/BookApiConsumer/Program.cs
+++ b/BookApiConsumer/Program.cs
@@ -1,4 +1,6 @@
 ﻿using Clients;
+using IdentityModel.Client;
+using Microsoft.Rest;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,12 +12,41 @@ namespace BookApiConsumer
         static async Task<int> Main(string[] args)
         {
             var httpClient = new HttpClient();
-            var client = new BookApiClient(httpClient, false)
+            var disco = await httpClient.GetDiscoveryDocumentAsync("http://localhost:5000");
+            if (disco.IsError)
+            {
+                Console.WriteLine(disco.Error);
+                return 1;
+            }
+
+            // request token
+            // client credentials would be used in service-to-service authentication and the
+            // returned token would most likely be a relatively long lived JWT
+            var tokenResponse = await httpClient.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            {
+                Address = disco.TokenEndpoint,
+
+                ClientId = "book-api-consumer",
+                ClientSecret = "secret",
+                Scope = "book-api.full-access"
+            });
+
+            if (tokenResponse.IsError)
+            {
+                Console.WriteLine(tokenResponse.Error);
+                return 1;
+            }
+
+            Console.WriteLine(tokenResponse.Json);
+
+            var apiClient = new BookApiClient(new TokenCredentials(tokenResponse.AccessToken), 
+                httpClient, false)
             {
                 BaseUri = new Uri("http://localhost:5001")
             };
 
-            var authors = await client.Authors.GetAllAsync();
+            // query API
+            var authors = await apiClient.Authors.GetAllAsync();
 
             foreach (var author in authors)
             {

--- a/IdentityServer/Config.cs
+++ b/IdentityServer/Config.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using IdentityServer4.Models;
+using System.Collections.Generic;
+
+namespace IdentityServer
+{
+    public static class Config
+    {
+        public static IEnumerable<IdentityResource> IdentityResources =>
+            new IdentityResource[]
+            {
+                new IdentityResources.OpenId()
+            };
+
+        public static IEnumerable<ApiScope> ApiScopes =>
+            new ApiScope[]
+            { new ApiScope("book-api.full-access")};
+
+        public static IEnumerable<Client> Clients =>
+            new Client[]
+            { new Client
+        {
+            ClientId = "book-api-consumer",
+
+            // no interactive user, use the clientid/secret for authentication
+            AllowedGrantTypes = GrantTypes.ClientCredentials,
+
+            // secret for authentication
+            ClientSecrets =
+            {
+                new Secret("secret".Sha256())
+            },
+
+            // scopes that client has access to
+            AllowedScopes = { "book-api.full-access" }
+        }};
+
+        public static IEnumerable<ApiResource> Apis =>
+            new List<ApiResource>
+            {
+                    new ApiResource("book-api", "My Book API")
+                    {
+                        Scopes = { "book-api.full-access"}
+                    }
+            };
+    }
+}

--- a/IdentityServer/IdentityServer.csproj
+++ b/IdentityServer/IdentityServer.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="IdentityServer4" Version="4.0.0" />
+
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+  </ItemGroup>
+</Project>

--- a/IdentityServer/Program.cs
+++ b/IdentityServer/Program.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
+using System;
+
+namespace IdentityServer
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                // uncomment to write to Azure diagnostics stream
+                //.WriteTo.File(
+                //    @"D:\home\LogFiles\Application\identityserver.txt",
+                //    fileSizeLimitBytes: 1_000_000,
+                //    rollOnFileSizeLimit: true,
+                //    shared: true,
+                //    flushToDiskInterval: TimeSpan.FromSeconds(1))
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Code)
+                .CreateLogger();
+
+            try
+            {
+                Log.Information("Starting host...");
+                CreateHostBuilder(args).Build().Run();
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly.");
+                return 1;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseSerilog()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/IdentityServer/Properties/launchSettings.json
+++ b/IdentityServer/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "SelfHost": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5000"
+    }
+  }
+}

--- a/IdentityServer/Startup.cs
+++ b/IdentityServer/Startup.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace IdentityServer
+{
+    public class Startup
+    {
+        public IWebHostEnvironment Environment { get; }
+
+        public Startup(IWebHostEnvironment environment)
+        {
+            Environment = environment;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // uncomment, if you want to add an MVC-based UI
+            //services.AddControllersWithViews();
+
+            var builder = services.AddIdentityServer(options =>
+            {
+                // see https://identityserver4.readthedocs.io/en/latest/topics/resources.html
+                options.EmitStaticAudienceClaim = true;
+            })
+                .AddInMemoryIdentityResources(Config.IdentityResources)
+                .AddInMemoryApiScopes(Config.ApiScopes)
+                .AddInMemoryClients(Config.Clients)
+                .AddInMemoryApiResources(Config.Apis);
+
+            // not recommended for production - you need to store your key material somewhere secure
+            builder.AddDeveloperSigningCredential();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (Environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            // uncomment if you want to add MVC
+            //app.UseStaticFiles();
+            //app.UseRouting();
+            
+            app.UseIdentityServer();
+
+            // uncomment, if you want to add MVC
+            //app.UseAuthorization();
+            //app.UseEndpoints(endpoints =>
+            //{
+            //    endpoints.MapDefaultControllerRoute();
+            //});
+        }
+    }
+}

--- a/OpenApiSample.sln
+++ b/OpenApiSample.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BookApi", "BookApi\BookApi.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BookApiClient", "BookApiClient\BookApiClient.csproj", "{F43DE13E-EC1D-488F-A64D-151526BC355E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookApiConsumer", "BookApiConsumer\BookApiConsumer.csproj", "{5ED6DB0F-CCF1-4370-9F23-0211543D0C84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BookApiConsumer", "BookApiConsumer\BookApiConsumer.csproj", "{5ED6DB0F-CCF1-4370-9F23-0211543D0C84}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentityServer", "IdentityServer\IdentityServer.csproj", "{946EC591-AF2C-43F4-83FD-AD95EE92A800}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{5ED6DB0F-CCF1-4370-9F23-0211543D0C84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5ED6DB0F-CCF1-4370-9F23-0211543D0C84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5ED6DB0F-CCF1-4370-9F23-0211543D0C84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{946EC591-AF2C-43F4-83FD-AD95EE92A800}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{946EC591-AF2C-43F4-83FD-AD95EE92A800}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{946EC591-AF2C-43F4-83FD-AD95EE92A800}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{946EC591-AF2C-43F4-83FD-AD95EE92A800}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is a very minimal implementation to show how to pass a token to an autorest client. Especially the server side code is not complete.

This PR contains the following changes:
1. Require authentication in the Book API (Any valid JWT is accepted, the API does not do 'real' verification of the token)
2. Generate the autorest client with credentials
3. Get a JWT from the Identity Server with the client credential grant and use this in the autorest client (both c# and typescript)

